### PR TITLE
Add `split` and `range` function

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -13,6 +13,7 @@
         "elm/core": "1.0.0 <= v < 2.0.0"
     },
     "test-dependencies": {
+        "elm/random": "1.0.0 <= v < 2.0.0",
         "elm-explorations/test": "1.2.2 <= v < 2.0.0"
     }
 }

--- a/src/IntDict.elm
+++ b/src/IntDict.elm
@@ -235,6 +235,7 @@ Find the highest bit not set in
     diff =
         x `xor` y
 
+
     -- 0b011001 `xor` 0b011010 = 0b000011
 
 -}

--- a/src/IntDict.elm
+++ b/src/IntDict.elm
@@ -623,6 +623,18 @@ partition predicate dict =
 {-| Split a dictionary around a pivot key. The first dictionary contains
 values whose key is less than the pivot, the second dictionary all values
 greater or equal the pivot.
+
+
+    dict =
+        fromList [ ( 0, "a" ), ( 1, "b" ), ( 2, "c" ), ( 5, "d" ) ]
+
+    ( lower, higher ) =
+        split 2 dict
+
+
+    -- toList lower == [ (0, "a"), (1, "b") ]
+    -- toList higher == [ (2, "c"), (5, "d") ]
+
 -}
 split : Int -> IntDict v -> ( IntDict v, IntDict v )
 split key dict =
@@ -662,6 +674,17 @@ split key dict =
 
 {-| Extract a range of keys. The returned dictionary has only items whose keys
 are between low (inclusive) and high (exclusive).
+
+
+    dict =
+        fromList [ ( 0, "a" ), ( 1, "b" ), ( 2, "c" ), ( 5, "d" ) ]
+
+    inRange =
+        range 1 5 dict
+
+
+    -- toList inRange == [ (1, "b"), (2, "c") ]
+
 -}
 range : Int -> Int -> IntDict v -> IntDict v
 range low high dict =

--- a/src/IntDict.elm
+++ b/src/IntDict.elm
@@ -4,7 +4,7 @@ module IntDict exposing
     , isEmpty, size, member, get, before, after, findMin, findMax
     , uniteWith, union, intersect, diff, merge
     , keys, values, toList, fromList
-    , map, foldl, foldr, filter, partition, split
+    , map, foldl, foldr, filter, partition, split, range
     , toString
     )
 
@@ -66,7 +66,7 @@ Dictionary equality with `(==)` is unreliable and should not be used.
 
 # Transform
 
-@docs map, foldl, foldr, filter, partition, split
+@docs map, foldl, foldr, filter, partition, split, range
 
 
 # String representation
@@ -658,6 +658,27 @@ split key dict =
 
             else
                 ( empty, dict )
+
+
+{-| Extract a range of keys. The returned dictionary has only items whose keys
+are between low (inclusive) and high (exclusive).
+-}
+range : Int -> Int -> IntDict v -> IntDict v
+range low high dict =
+    let
+        low_ =
+            min low high
+
+        high_ =
+            max low high
+
+        ( lessThanHigh, _ ) =
+            split high_ dict
+
+        ( _, greaterThanLow ) =
+            split low_ lessThanHigh
+    in
+    greaterThanLow
 
 
 

--- a/tests/Tests/IntDict.elm
+++ b/tests/Tests/IntDict.elm
@@ -1,4 +1,4 @@
-module Tests.IntDict exposing (build, combine, merge, moreNumbers, numbers, query, regressions, split, transform)
+module Tests.IntDict exposing (build, combine, merge, moreNumbers, numbers, query, range, regressions, split, transform)
 
 {-| Copied and modified from `Dict`s test suite.
 -}
@@ -209,6 +209,28 @@ split =
             \() ->
                 Expect.equal ( [ ( -1, -1 ), ( 0, 0 ) ], [] )
                     (IntDict.split 2147483648 (IntDict.fromList [ ( -1, -1 ), ( 0, 0 ) ]) |> toLists)
+        ]
+
+
+orderedTuple : Fuzz.Fuzzer ( Int, Int )
+orderedTuple =
+    Fuzz.tuple ( Fuzz.int, Fuzz.int )
+        |> Fuzz.map (\( a, b ) -> ( min a b, max a b ))
+
+
+range : Test
+range =
+    describe "range" <|
+        [ fuzz2 orderedTuple randomDict "range on random dictionaries" <|
+            \( low, high ) dict ->
+                let
+                    items =
+                        IntDict.toList dict
+
+                    expected =
+                        List.filter (\( a, _ ) -> a >= low && a < high) items
+                in
+                Expect.equal expected (IntDict.range low high dict |> IntDict.toList)
         ]
 
 

--- a/tests/Tests/IntDict.elm
+++ b/tests/Tests/IntDict.elm
@@ -144,6 +144,19 @@ merge =
         ]
 
 
+maxInt =
+    2 ^ 31 - 1
+
+
+minInt =
+    -(2 ^ 31)
+
+
+validKey : Fuzz.Fuzzer Int
+validKey =
+    Fuzz.intRange minInt maxInt
+
+
 randomDict : Fuzz.Fuzzer (IntDict Int)
 randomDict =
     Fuzz.list Fuzz.int
@@ -194,7 +207,7 @@ split =
             \() ->
                 Expect.equal ( [ ( -10, -10 ), ( 0, 0 ), ( 1, 1 ), ( 2, 2 ), ( 3, 3 ) ], [ ( 100, 100 ) ] )
                     (IntDict.split 5 s2 |> toLists)
-        , fuzz2 Fuzz.int randomDict "split on random dictionaries" <|
+        , fuzz2 validKey randomDict "split on random dictionaries" <|
             \key dict ->
                 let
                     items =
@@ -205,16 +218,12 @@ split =
                 in
                 Expect.equal ( expectedLessThan, expectedGreaterEq )
                     (IntDict.split key dict |> toLists)
-        , test "split on special case" <|
-            \() ->
-                Expect.equal ( [ ( -1, -1 ), ( 0, 0 ) ], [] )
-                    (IntDict.split 2147483648 (IntDict.fromList [ ( -1, -1 ), ( 0, 0 ) ]) |> toLists)
         ]
 
 
 orderedTuple : Fuzz.Fuzzer ( Int, Int )
 orderedTuple =
-    Fuzz.tuple ( Fuzz.int, Fuzz.int )
+    Fuzz.tuple ( validKey, validKey )
         |> Fuzz.map (\( a, b ) -> ( min a b, max a b ))
 
 

--- a/tests/Tests/IntDict.elm
+++ b/tests/Tests/IntDict.elm
@@ -149,14 +149,6 @@ merge =
 randomValidKey : Random.Generator Int
 randomValidKey =
     Random.int Random.minInt Random.maxInt
-        |> Random.andThen
-            (\key ->
-                if IntDict.isValidKey key then
-                    Random.constant key
-
-                else
-                    randomValidKey
-            )
 
 
 validKey : Fuzz.Fuzzer Int

--- a/tests/Tests/IntDict.elm
+++ b/tests/Tests/IntDict.elm
@@ -207,8 +207,8 @@ split =
                     (IntDict.split key dict |> toLists)
         , test "split on special case" <|
             \() ->
-                Expect.equal ([(-1,-1),(0,0)],[])
-                    (IntDict.split 2147483648 (IntDict.fromList [ ( -1, -1 ), ( 0, 0 )]) |> toLists)
+                Expect.equal ( [ ( -1, -1 ), ( 0, 0 ) ], [] )
+                    (IntDict.split 2147483648 (IntDict.fromList [ ( -1, -1 ), ( 0, 0 ) ]) |> toLists)
         ]
 
 


### PR DESCRIPTION
Addressing issue #10 
Notice that one of the tests does not pass. I'm not sure why, I would like it if someone will take a look. It is possible that `isPrefixMatching` returns wrong result in this edge case?